### PR TITLE
Add missing routeParams

### DIFF
--- a/examples/full/routes/child-routes/google-books/components/index.js
+++ b/examples/full/routes/child-routes/google-books/components/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createReducer } from 'redux-act';
-import { merge, map } from 'lodash';
+import { map } from 'lodash';
 
 import Book from 'examples/full/routes/child-routes/google-books/components/book';
 import createActions from 'examples/utils/createActions';
@@ -11,14 +11,10 @@ const FROWN_FACE = ':(';
 export const actions = createActions('GoogleBooks', ['loadTop', 'loadBottom']);
 export const reducer = createReducer({
   [actions.loadTop]: (state, payload) => {
-    const updatedState = merge({}, state);
-    updatedState.topBooks = payload;
-    return updatedState;
+    return { ...state, topBooks: payload };
   },
   [actions.loadBottom]: (state, payload) => {
-    const updatedState = merge({}, state);
-    updatedState.bottomBooks = payload;
-    return updatedState;
+    return { ...state, bottomBooks: payload };
   },
 }, {
   topBooks: [],
@@ -52,7 +48,7 @@ export default props => {
 
   return (
     <div style={routeStyle}>
-      <div style={merge({}, booksSectionStyle, { marginBottom: 20 })}>
+      <div style={{ ...booksSectionStyle, marginBottom: 20 }}>
         <p style={{ marginTop: 0 }}>Top of page</p>
         <div>{topBooks}</div>
       </div>

--- a/examples/full/routes/child-routes/google-books/components/index.js
+++ b/examples/full/routes/child-routes/google-books/components/index.js
@@ -8,21 +8,21 @@ import { routeStyle, booksSectionStyle, previewTemplateStyle } from 'examples/ut
 
 const FROWN_FACE = ':(';
 
-export const actions = createActions('GoogleBooks', ['loadFiction', 'loadJavascript']);
+export const actions = createActions('GoogleBooks', ['loadTop', 'loadBottom']);
 export const reducer = createReducer({
-  [actions.loadFiction]: (state, payload) => {
+  [actions.loadTop]: (state, payload) => {
     const updatedState = merge({}, state);
-    updatedState.fiction = payload;
+    updatedState.topBooks = payload;
     return updatedState;
   },
-  [actions.loadJavascript]: (state, payload) => {
+  [actions.loadBottom]: (state, payload) => {
     const updatedState = merge({}, state);
-    updatedState.javascript = payload;
+    updatedState.bottomBooks = payload;
     return updatedState;
   },
 }, {
-  fiction: [],
-  javascript: [],
+  topBooks: [],
+  bottomBooks: [],
 });
 
 export default props => {
@@ -34,7 +34,7 @@ export default props => {
       <div>{FROWN_FACE}</div>
     );
   } else {
-    topBooks = map(data.fiction, (book, index) => (
+    topBooks = map(data.topBooks, (book, index) => (
       <Book key={index} {...book} />
     ));
   }
@@ -45,7 +45,7 @@ export default props => {
       <div key={index} style={previewTemplateStyle} />
     ));
   } else {
-    bottomBooks = map(data.javascript, (book, index) => (
+    bottomBooks = map(data.bottomBooks, (book, index) => (
       <Book key={index} {...book} />
     ));
   }
@@ -53,11 +53,11 @@ export default props => {
   return (
     <div style={routeStyle}>
       <div style={merge({}, booksSectionStyle, { marginBottom: 20 })}>
-        <p style={{ marginTop: 0 }}>Top of page: fiction</p>
+        <p style={{ marginTop: 0 }}>Top of page</p>
         <div>{topBooks}</div>
       </div>
       <div style={booksSectionStyle}>
-        <p style={{ marginTop: 0 }}>Bottom of page: javascript</p>
+        <p style={{ marginTop: 0 }}>Bottom of page</p>
         <div>{bottomBooks}</div>
       </div>
     </div>

--- a/examples/full/routes/child-routes/google-books/index.js
+++ b/examples/full/routes/child-routes/google-books/index.js
@@ -3,13 +3,10 @@ import component, { reducer, actions } from 'examples/full/routes/child-routes/g
 import loader from 'examples/full/routes/child-routes/google-books/components/loader';
 
 const cache = {};
-const FICTION_KEY = 'FICTION';
 const UNAUTHORIZED = 'Unauthorized';
 const SERVER_ERROR = 'ServerError';
 
 const API = 'https://www.googleapis.com/books/v1/volumes?q=subject:';
-const FICTION = `${API}fiction`;
-const JAVASCRIPT = `${API}javascript`;
 
 // handle errors however youd like...
 const handleErrors = params => response => {
@@ -27,19 +24,19 @@ const adjustResponse = data => map(data.items, item => {
   return adjustedItem;
 });
 
-const fetchTopOfPageData = async (params, isClient) => new Promise((resolve, reject) => {
-  if (cache[FICTION_KEY]) {
-    if (params.error) reject(SERVER_ERROR); // for sake of demo
-    if (params.redirect) reject(UNAUTHORIZED);
-    resolve(cache[FICTION_KEY]);
+const fetchTopOfPageData = async (key, queryParams, isClient) => new Promise((resolve, reject) => {
+  if (cache[key]) {
+    if (queryParams.error) reject(SERVER_ERROR); // for sake of demo
+    if (queryParams.redirect) reject(UNAUTHORIZED);
+    resolve(cache[key]);
   } else {
     setTimeout(() => {
-      fetch(FICTION)
-          .then(handleErrors(params))
+      fetch(`${API}${key}`)
+          .then(handleErrors(queryParams))
           .then(response => response.json())
           .then(adjustResponse)
           .then(books => {
-            if (isClient) cache[FICTION_KEY] = books;
+            if (isClient) cache[key] = books;
             resolve(books);
           }).catch(error => {
             reject(error.message);
@@ -48,9 +45,9 @@ const fetchTopOfPageData = async (params, isClient) => new Promise((resolve, rej
   }
 });
 
-const fetchBottomOfPageData = async () => new Promise(resolve => {
+const fetchBottomOfPageData = async (key) => new Promise(resolve => {
   setTimeout(() => {
-    fetch(JAVASCRIPT)
+    fetch(`${API}${key}`)
         .then(response => response.json())
         .then(adjustResponse)
         .then(books => resolve(books));
@@ -59,16 +56,19 @@ const fetchBottomOfPageData = async () => new Promise(resolve => {
 
 // Complex example to show full power of API!
 const fetchData = async (done, {
-  params, dispatch, isHydrated, clientRender, serverRender,
+  routeParams, queryParams, dispatch, isHydrated, clientRender, serverRender,
   isClient, isMounted, hydratedDataForRoute, err, redirect,
 }) => {
+  const topKey = routeParams.top;
+  const bottomKey = routeParams.bottom;
+
   if (isHydrated()) {
     const hydratedData = hydratedDataForRoute();
-    if (hydratedData && hydratedData.fiction) cache[FICTION_KEY] = hydratedData.fiction;
+    if (hydratedData && hydratedData.top) cache[topKey] = hydratedData.top;
   } else {
     try {
-      const books = await fetchTopOfPageData(params, isClient());
-      if (isMounted()) dispatch(actions.loadFiction(books));
+      const books = await fetchTopOfPageData(routeParams, queryParams, isClient());
+      if (isMounted()) dispatch(actions.loadTop(books));
     } catch (e) {
       if (e === SERVER_ERROR) {
         err({ topBooks: true, message: 'Nope!' });
@@ -82,14 +82,14 @@ const fetchData = async (done, {
   serverRender();
 
   if (isClient()) {
-    const books = await fetchBottomOfPageData();
-    if (isMounted()) dispatch(actions.loadJavascript(books));
+    const books = await fetchBottomOfPageData(bottomKey);
+    if (isMounted()) dispatch(actions.loadBottom(books));
     done();
   }
 };
 
 export default {
-  path: '/google-books',
+  path: '/google-books/:top/:bottom',
   component,
   reducer,
   fetchData,

--- a/examples/full/routes/child-routes/nested-counters/child-routes/multiply-counter/components/index.js
+++ b/examples/full/routes/child-routes/nested-counters/child-routes/multiply-counter/components/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createReducer } from 'redux-act';
-import { merge } from 'lodash';
 
 import createActions from 'examples/utils/createActions';
 import { routeStyle } from 'examples/utils/style';
@@ -8,9 +7,7 @@ import { routeStyle } from 'examples/utils/style';
 export const actions = createActions('MultiplyCounters', ['incr']);
 export const reducer = createReducer({
   [actions.incr]: (state) => {
-    const updatedState = merge({}, state);
-    updatedState.counter *= 2;
-    return updatedState;
+    return { ...state, counter: state.counter * 2 };
   },
 }, {
   counter: 3,

--- a/examples/full/routes/child-routes/nested-counters/child-routes/square-counter/components/index.js
+++ b/examples/full/routes/child-routes/nested-counters/child-routes/square-counter/components/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createReducer } from 'redux-act';
-import { merge } from 'lodash';
 
 import createActions from 'examples/utils/createActions';
 import { routeStyle } from 'examples/utils/style';
@@ -8,9 +7,7 @@ import { routeStyle } from 'examples/utils/style';
 export const actions = createActions('SquareCounter', ['incr']);
 export const reducer = createReducer({
   [actions.incr]: (state) => {
-    const updatedState = merge({}, state);
-    updatedState.counter *= state.counter;
-    return updatedState;
+    return { ...state, counter: state.counter * state.counter };
   },
 }, {
   counter: 3,

--- a/examples/full/routes/child-routes/nested-counters/components/index.js
+++ b/examples/full/routes/child-routes/nested-counters/components/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { IndexLink, Link } from 'react-router';
 import { createReducer } from 'redux-act';
-import { merge } from 'lodash';
-import { getNestedState } from 'modules/GroundControl';
 
 import { actions as appActions } from 'examples/full/routes/components/index';
 import createActions from 'examples/utils/createActions';
@@ -11,9 +9,7 @@ import { routeStyle, navStyle, linkStyle, activeLinkStyle } from 'examples/utils
 export const actions = createActions('NestedCounters', ['incr']);
 export const reducer = createReducer({
   [actions.incr]: (state, payload) => {
-    const updatedState = merge({}, state);
-    updatedState.counter += payload;
-    return updatedState;
+    return { ...state, counter: state.counter + payload };
   },
 }, {
   counter: 0,

--- a/examples/full/routes/child-routes/nested-counters/index-route/components/index.js
+++ b/examples/full/routes/child-routes/nested-counters/index-route/components/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createReducer } from 'redux-act';
-import { merge } from 'lodash';
 
 import createActions from 'examples/utils/createActions';
 import { routeStyle } from 'examples/utils/style';
@@ -8,9 +7,7 @@ import { routeStyle } from 'examples/utils/style';
 export const actions = createActions('NestedCountersIndex', ['incr']);
 export const reducer = createReducer({
   [actions.incr]: (state) => {
-    const updatedState = merge({}, state);
-    updatedState.counter += 1;
-    return updatedState;
+    return { ...state, counter: state.counter + 1 };
   },
 }, {
   counter: 0,

--- a/examples/full/routes/components/index.js
+++ b/examples/full/routes/components/index.js
@@ -27,16 +27,16 @@ const inlineLinkProps = error => ({
 });
 
 export default props => {
-  const { children, dispatch } = props;
+  const { children } = props;
   return (
     <div style={routeStyle}>
       <h4 style={{ margin: '0 0 20px' }}>GroundControl - Example</h4>
       <div style={navStyle}>
         <IndexLink to="/" {...linkProps()}>Palindrome (Combined / Immutable Reducers Demo)</IndexLink>
         <div style={{ marginBottom: 10 }}>
-          <Link to={{ pathname: '/google-books' }} {...inlineLinkProps()}>Google Books (Data Fetching Demo)</Link>
-          <Link to={{ pathname: '/google-books', query: { error: true }}} {...inlineLinkProps(true)}>(Demo ?error=true)</Link>
-          <Link to={{ pathname: '/google-books', query: { redirect: true }}} {...inlineLinkProps(true)}>(Demo ?redirect=true)</Link>
+          <Link to={{ pathname: '/google-books/fiction/javascript' }} {...inlineLinkProps()}>Google Books (Data Fetching Demo)</Link>
+          <Link to={{ pathname: '/google-books/fiction/javascript', query: { error: true }}} {...inlineLinkProps(true)}>(Demo ?error=true)</Link>
+          <Link to={{ pathname: '/google-books/fiction/javascript', query: { redirect: true }}} {...inlineLinkProps(true)}>(Demo ?redirect=true)</Link>
         </div>
         <Link to="/nested-counters" {...linkProps()}>Nested Counters (Nested Reducers Demo)</Link>
       </div>

--- a/examples/full/routes/components/index.js
+++ b/examples/full/routes/components/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { IndexLink, Link } from 'react-router';
 import { createReducer } from 'redux-act';
-import { merge } from 'lodash';
 
 import createActions from 'examples/utils/createActions';
 import { routeStyle, navStyle, linkStyle, inlineLinkStyle, errorLinkStyle, activeLinkStyle } from 'examples/utils/style';
@@ -9,10 +8,8 @@ import { routeStyle, navStyle, linkStyle, inlineLinkStyle, errorLinkStyle, activ
 export const actions = createActions('Index', ['incr']);
 export const reducer = createReducer({
   [actions.incr]: (state, payload) => {
-    if (!state.counter) state.counter = 0;
-    const updatedState = merge({}, state);
-    updatedState.counter += payload;
-    return updatedState;
+    const counter = (state.counter || 0) + payload;
+    return { ...state, counter };
   },
 }, {});
 

--- a/examples/simple/components/home.js
+++ b/examples/simple/components/home.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { merge } from 'lodash';
 import { routeStyle } from 'examples/utils/style';
 
 const initialState = { counter: 0 };
@@ -11,9 +10,7 @@ export const actions = {
 export const reducer = (state = initialState, action) => {
   switch (action.type) {
   case 'HomeIncr':
-    const updatedState = merge({}, state);
-    updatedState.counter += action.payload;
-    return updatedState;
+    return { ...state, counter: state.counter + action.payload };
   default:
     return state;
   }

--- a/examples/simple/components/route-2.js
+++ b/examples/simple/components/route-2.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { merge, map } from 'lodash';
+import { map } from 'lodash';
 import { routeStyle, previewTemplateStyle } from 'examples/utils/style';
 
 const initialState = { items: [] };
@@ -11,9 +11,7 @@ export const actions = {
 export const reducer = (state = initialState, action) => {
   switch (action.type) {
   case 'Route2Load':
-    const updatedState = merge({}, state);
-    updatedState.items = action.payload;
-    return updatedState;
+    return { ...state, items: action.payload };
   default:
     return state;
   }

--- a/examples/utils/style.js
+++ b/examples/utils/style.js
@@ -1,18 +1,17 @@
 // Recommend using cssmodules, but this is fine for demo...
 
-import { merge } from 'lodash';
-
 export const routeStyle = {
   padding: 20,
   border: '1px solid #31c1c9',
 };
 
-export const navStyle = merge({}, routeStyle, {
+export const navStyle = {
+  ...routeStyle,
   borderColor: '#b0babf',
   backgroundColor: '#f4f6f6',
   marginBottom: 20,
   paddingBottom: 10,
-});
+};
 
 export const linkStyle = {
   display: 'block',
@@ -21,14 +20,16 @@ export const linkStyle = {
   textDecoration: 'none',
 };
 
-export const inlineLinkStyle = merge({}, linkStyle, {
+export const inlineLinkStyle = {
+  ...linkStyle,
   display: 'inline',
   marginRight: 5,
-});
+};
 
-export const errorLinkStyle = merge({}, inlineLinkStyle, {
+export const errorLinkStyle = {
+  ...inlineLinkStyle,
   color: '#ea5454',
-});
+};
 
 export const activeLinkStyle = {
   fontWeight: 'bold',

--- a/modules/GroundControl.js
+++ b/modules/GroundControl.js
@@ -58,7 +58,7 @@ class GroundControl extends React.Component {
   }
 
   componentDidMount() {
-    const { location, store } = this.props;
+    const { location, store, params: routeParams } = this.props;
     const { routes } = this.state;
 
     this.unsubscribe = store.subscribe(() => {
@@ -66,7 +66,7 @@ class GroundControl extends React.Component {
       this.setState({ storeState });
     });
 
-    this.loadAsyncState(routes, location.query, ROOT_DEPTH);
+    this.loadAsyncState(routes, location.query, routeParams, ROOT_DEPTH);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -78,7 +78,7 @@ class GroundControl extends React.Component {
     const routeChanged = pathChanged || searchChanged;
     if (!routeChanged) return;
 
-    const { location, routes } = nextProps;
+    const { location, routes, params: routeParams } = nextProps;
     const routeDiff = diffRoutes(prevRoutes, routes);
     const sameRoutes = take(routes, routeDiff);
     const differentRoutes = normalizeRoutes(drop(routes, routeDiff), true);
@@ -86,7 +86,7 @@ class GroundControl extends React.Component {
 
     const useInitialState = false;
     this.setState({ routes: nextRoutes, useInitialState }, () => {
-      this.loadAsyncState(nextRoutes, location.query, routeDiff);
+      this.loadAsyncState(nextRoutes, location.query, routeParams, routeDiff);
     });
   }
 
@@ -139,7 +139,7 @@ class GroundControl extends React.Component {
     return this.state.routes[index] === route;
   }
 
-  loadAsyncState(routes, params, replaceAtDepth) {
+  loadAsyncState(routes, queryParams, routeParams, replaceAtDepth) {
     const { store, initialData } = this.props;
     const { useInitialState } = this.state;
     const { initialState } = initialData;
@@ -147,7 +147,8 @@ class GroundControl extends React.Component {
     this.nestReducers(useInitialState, routes, replaceAtDepth);
     loadAsyncState(
       routes,
-      params,
+      queryParams,
+      routeParams,
       store,
       this.fetchDataCallback.bind(this),
       this.stillActiveCallback.bind(this),

--- a/modules/deserialize.js
+++ b/modules/deserialize.js
@@ -1,10 +1,10 @@
 import { setNestedState, getNestedState } from './nestedState';
 import { validateRootShape, setShape } from './nestedShape';
-import { forEach, merge } from 'lodash';
+import { forEach } from 'lodash';
 import { NAMESPACE } from './constants';
 
 export default (state, routes, deserializer = null) => {
-  const updatedState = merge({}, state);
+  const updatedState = { ...state };
   if (!validateRootShape(updatedState)) {
     return {
       ...updatedState,

--- a/modules/loadAsyncState.js
+++ b/modules/loadAsyncState.js
@@ -22,7 +22,8 @@ const _serverRender = (cb, route, index) => {
 
 export default (
   routes,
-  params,
+  queryParams,
+  routeParams,
   store,
   fetchDataCallback,
   stillActive,
@@ -48,8 +49,8 @@ export default (
 
       if (route.fetchData) {
         route.fetchData(done, {
-          clientRender, serverRender, redirect, err,
-          params, dispatch, getState, isMounted, isClient,
+          clientRender, serverRender, redirect, err, routeParams,
+          queryParams, dispatch, getState, isMounted, isClient,
           isHydrated, hydratedDataForRoute, isServer,
         });
       } else {

--- a/modules/loadStateOnServer.js
+++ b/modules/loadStateOnServer.js
@@ -62,7 +62,7 @@ export default ({
   store,
   reducers,
 }, cb) => {
-  const { routes, location } = props;
+  const { routes, location, params: routeParams } = props;
 
   const initialRoutes = normalizeRoutes(routes);
   const fetchDataCallback = createFetchDataCallback(initialRoutes, store, cb);
@@ -78,6 +78,7 @@ export default ({
   loadAsyncState(
     initialRoutes,
     location.query,
+    routeParams,
     store,
     fetchDataCallback,
     stillActiveCallback,


### PR DESCRIPTION
Fixes https://github.com/raisemarketplace/ground-control/issues/9

`fetchData` can now accept parameters from the current route.

``` js
// `options` now includes `routeParams` and `queryParams`
function fetchMyData(done, options) {
  let { routeParams, queryParams } = options;
  console.log(routeParams);
  console.log(queryParams);
  done();
}
```
