### PR TITLE
Pass dispatch to the onLeave API

### DIFF
--- a/modules/normalizeRoutes.js
+++ b/modules/normalizeRoutes.js
@@ -15,6 +15,7 @@ export default (routes, props, startIndex = ROOT_DEPTH, force = false) => {
           getReducerState,
           params,
           query,
+          dispatch: store.dispatch,
         });
       }
 


### PR DESCRIPTION
This update allows to send out actions right before leaving the current route.
